### PR TITLE
Enable cascading deletes, change bi-directional relationships to uni-directional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,17 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<optional>true</optional>
 		</dependency>
-
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/src/main/java/com/socialcoding/workout/workoutlogger/entity/Exercise.java
+++ b/src/main/java/com/socialcoding/workout/workoutlogger/entity/Exercise.java
@@ -1,5 +1,9 @@
 package com.socialcoding.workout.workoutlogger.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import javax.persistence.*;
 
 @Entity
@@ -8,7 +12,7 @@ public class Exercise {
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private int id;
 
-    @Column(nullable =  false)
+    @Column(nullable = false)
     private String name;
 
     @Column(nullable = false)
@@ -17,7 +21,10 @@ public class Exercise {
     @Column(nullable = false)
     private int reps;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "workout_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JsonIgnore
     private Workout workout;
 
     protected Exercise() {}
@@ -44,7 +51,7 @@ public class Exercise {
         return reps;
     }
 
-    public Workout getWorkouts() {
+    public Workout getWorkout() {
         return workout;
     }
 

--- a/src/main/java/com/socialcoding/workout/workoutlogger/entity/User.java
+++ b/src/main/java/com/socialcoding/workout/workoutlogger/entity/User.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 public class User {
@@ -18,9 +16,6 @@ public class User {
 
     @Column(nullable = false)
     private String password;
-
-    @OneToMany(cascade = CascadeType.ALL)
-    private List<Workout> workouts = new ArrayList<>();
 
     protected User() {}
 
@@ -42,10 +37,6 @@ public class User {
         return password;
     }
 
-    public List<Workout> getWorkouts() {
-        return workouts;
-    }
-
     public void setId(int id) {
         this.id = id;
     }
@@ -57,10 +48,6 @@ public class User {
     @JsonProperty
     public void setPassword(String password) {
         this.password = password;
-    }
-
-    public void setWorkouts(List<Workout> workouts) {
-        this.workouts = workouts;
     }
 
     @Override

--- a/src/main/java/com/socialcoding/workout/workoutlogger/entity/Workout.java
+++ b/src/main/java/com/socialcoding/workout/workoutlogger/entity/Workout.java
@@ -1,8 +1,11 @@
 package com.socialcoding.workout.workoutlogger.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import javax.persistence.*;
 import java.util.Date;
-import java.util.List;
 
 @Entity
 public class Workout {
@@ -10,12 +13,11 @@ public class Workout {
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private int id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JsonIgnore
     private User user;
-
-    @OneToMany
-    private List<Exercise> exercises;
 
     @Temporal(TemporalType.DATE)
     @Column(nullable = false)
@@ -58,10 +60,6 @@ public class Workout {
         return user;
     }
 
-    public List<Exercise> getExercises() {
-        return exercises;
-    }
-
     public Date getDate() {
         return date;
     }
@@ -80,10 +78,6 @@ public class Workout {
 
     public void setUser(User user) {
         this.user = user;
-    }
-
-    public void setExercises(List<Exercise> exercises) {
-        this.exercises = exercises;
     }
 
     public void setDate(Date date) {


### PR DESCRIPTION
Enable cascading deletes by adding the `@OnDelete(action = OnDeleteAction.CASCADE)` annotation to the User object in the Workout class, and changing the bi-directional relationship between Users and Workouts to a uni-directional relationship.